### PR TITLE
Custom Upload and Assay Updates (bug fixes)

### DIFF
--- a/inst/shiny/tests/testthat/test-edge-cases.R
+++ b/inst/shiny/tests/testthat/test-edge-cases.R
@@ -55,16 +55,14 @@ test_that("app does not crash when accessed before uploading Seurat file", {
 # ── Bug 1: corrMat double transpose — compound dropdown must show drug names ──
 
 test_that("corrMat upload shows drug names in compound dropdown, not cell barcodes", {
-  skip_if_not(
-    file.exists(test_path("fixtures/downsampled_seuratObj.RDS")),
-    "Seurat fixture not available (requires Git LFS)"
-  )
+  fixture <- normalizePath(test_path("fixtures/downsampled_seuratObj.RDS"), mustWork = FALSE)
+  skip_if_not(file.exists(fixture), "Seurat fixture not available (requires Git LFS)")
   drug_names    <- c("DrugA", "DrugB", "DrugC")
   corr_mat_path <- make_corr_mat_csv(drug_names)
 
   app <- make_app("corr-mat-orientation")
 
-  app$upload_file(seurobjRDS = test_path("fixtures/downsampled_seuratObj.RDS"))
+  app$upload_file(seurobjRDS = fixture)
   app$wait_for_value(output = "seuratLoaded", timeout = 30000)
 
   app$set_inputs(uploadCorrelationMatrix = TRUE)
@@ -96,10 +94,8 @@ test_that("corrMat upload shows drug names in compound dropdown, not cell barcod
 # ── Bug 2: duplicate uiOutput — compound dropdown must not be empty ───────────
 
 test_that("reference compound dropdown is populated after corrMat upload", {
-  skip_if_not(
-    file.exists(test_path("fixtures/downsampled_seuratObj.RDS")),
-    "Seurat fixture not available (requires Git LFS)"
-  )
+  fixture <- normalizePath(test_path("fixtures/downsampled_seuratObj.RDS"), mustWork = FALSE)
+  skip_if_not(file.exists(fixture), "Seurat fixture not available (requires Git LFS)")
   # uiOutput('referenceCompound_ui') appears in two tabs in ui.R.
   # When the same output ID is bound twice, the second binding can
   # overwrite the first, leaving one tab's dropdown empty.
@@ -108,7 +104,7 @@ test_that("reference compound dropdown is populated after corrMat upload", {
 
   app <- make_app("duplicate-ui-output")
 
-  app$upload_file(seurobjRDS = test_path("fixtures/downsampled_seuratObj.RDS"))
+  app$upload_file(seurobjRDS = fixture)
   app$wait_for_value(output = "seuratLoaded", timeout = 30000)
 
   app$set_inputs(uploadCorrelationMatrix = TRUE)
@@ -136,10 +132,8 @@ test_that("reference compound dropdown is populated after corrMat upload", {
 # ── Bug 5: lowercase gene names in custom drug signature should not crash ─────
 
 test_that("custom drug signature with lowercase gene names does not crash app", {
-  skip_if_not(
-    file.exists(test_path("fixtures/downsampled_seuratObj.RDS")),
-    "Seurat fixture not available (requires Git LFS)"
-  )
+  fixture <- normalizePath(test_path("fixtures/downsampled_seuratObj.RDS"), mustWork = FALSE)
+  skip_if_not(file.exists(fixture), "Seurat fixture not available (requires Git LFS)")
   # If gene names in the uploaded CSV are lowercase (e.g. tp53) but the
   # Seurat object uses uppercase (TP53), overlap detection returns 0 and
   # the server calls stop(), crashing the reactive chain silently.
@@ -148,7 +142,7 @@ test_that("custom drug signature with lowercase gene names does not crash app", 
 
   app <- make_app("gene-case-mismatch")
 
-  app$upload_file(seurobjRDS = test_path("fixtures/downsampled_seuratObj.RDS"))
+  app$upload_file(seurobjRDS = fixture)
   app$wait_for_value(output = "seuratLoaded", timeout = 30000)
 
   app$set_inputs(L1000_Release = "Custom Upload")

--- a/inst/shiny/tests/testthat/test-upload.R
+++ b/inst/shiny/tests/testthat/test-upload.R
@@ -15,10 +15,13 @@ test_that("app loads without errors", {
 })
 
 test_that("uploading a valid Seurat RDS shows success message", {
-  skip_if_not(
-    file.exists(test_path("fixtures/downsampled_seuratObj.RDS")),
-    "Seurat fixture not available (requires Git LFS)"
+  # Resolve to absolute path NOW, before AppDriver can change the working dir
+  fixture <- normalizePath(
+    test_path("fixtures/downsampled_seuratObj.RDS"),
+    mustWork = FALSE
   )
+  skip_if_not(file.exists(fixture), "Seurat fixture not available (requires Git LFS)")
+
   app <- AppDriver$new(
     app_dir      = system.file("shiny", package = "scFOCAL"),
     name         = "seurat-upload",
@@ -26,9 +29,7 @@ test_that("uploading a valid Seurat RDS shows success message", {
     timeout      = 120000
   )
 
-  app$upload_file(
-    seurobjRDS = test_path("fixtures/downsampled_seuratObj.RDS")
-  )
+  app$upload_file(seurobjRDS = fixture)
 
   # Wait for seuratLoaded to be TRUE. Ignore NULL (pre-upload) and any
   # transient FALSE that may arrive while the 134 MB file is being read.


### PR DESCRIPTION
## Summary

Fixes five bugs identified during code review of the custom upload and assay selection features:

- **Bug 1 — corrMat orientation**: Removed erroneous `t()` in `corrMatUpload()` so the compound dropdown shows drug names, not cell barcodes
- **Bug 2 — `referenceCompound_ui` not evaluating**: Added `outputOptions(output, 'referenceCompound_ui', suspendWhenHidden = FALSE)` so the dropdown populates correctly when inside a hidden `conditionalPanel`
- **Bug 4 — pre-upload crash**: `assay_to_use()` now guards with `req(rdsSeurat())` before calling `isOrthogonAL()` so navigating the app before uploading a Seurat file doesn't crash
- **Bug 5 — gene case mismatch**: `drugSignatures()` normalises gene names with `toupper()` so lowercase uploads don't produce 0-gene overlap and a silent crash
- **Latent bug — `seq_len` fix**: Four `for (i in 1:length(...))` loops in the combination analysis replaced with `seq_len(nrow(...))` to avoid the `1:0 = c(1, 0)` trap on empty data frames

## Testing

Added a shinytest2 regression suite (`inst/shiny/tests/testthat/`) with tests for all five bugs. CI runs on every PR via `.github/workflows/shinytest2.yml`. The 134 MB Seurat fixture is tracked via Git LFS; tests that need it skip gracefully when LFS is unavailable.